### PR TITLE
Feysel.import export css

### DIFF
--- a/snap-css-web/src/util/fileImportExport.ts
+++ b/snap-css-web/src/util/fileImportExport.ts
@@ -1,0 +1,33 @@
+export default class FileImportExport {
+    public checkVueHTML(fileName: string): boolean {
+        return fileName.endsWith('.html') || fileName.endsWith('.vue');
+    }
+
+    public extractCSSFromHtmlOrVue(importedFile: string): string {
+        if (importedFile.indexOf('<style') === -1) {
+            return '';
+        }
+        let start: number = importedFile.indexOf('<style>');
+        if (start === -1) {
+            start = importedFile.indexOf('<style scoped>') + 7;
+        }
+        const end: number = importedFile.indexOf('</style>');
+        return importedFile.substring(start + 7, end);
+    }
+
+    public exportToVueHTML(toBeExported: string, content: string): string {
+        let start: number = toBeExported.indexOf('<style>');
+        if (start === -1) {
+            start = toBeExported.indexOf('<style scoped>') + 7;
+        }
+        const end: number = toBeExported.indexOf('</style>');
+        const parssedString =
+            toBeExported.substring(0, start + 7) +
+            '\n' + content +
+            toBeExported.substr(end);
+
+        return `data:text/plain;charset=utf-8, ${encodeURIComponent(
+            parssedString
+        )}`;
+    }
+}

--- a/snap-css-web/src/views/Home.vue
+++ b/snap-css-web/src/views/Home.vue
@@ -18,11 +18,15 @@
                   type="file"
                   class="d-none"
                   ref="cssFileInput"
-                  accept="text/css"
+                  accept=".css,.html,.vue"
                   @change="uploadCSS"
                 />
 
-                <button id='load-url-btn' @click="loadUrl" class="editor__btn util-btn">
+                <button
+                  id="load-url-btn"
+                  @click="loadUrl"
+                  class="editor__btn util-btn"
+                >
                   <mdi :path="mdiLink" size="20" />
                   <span class="icon_label">Load URL</span>
                 </button>
@@ -38,14 +42,10 @@
             </div>
           </div>
         </editor>
-        <editor
-          class="output"
-          v-model:code="outputText"
-          :options="{ readOnly: true }"
-        >
+        <editor class="output" v-model:code="outputText">
           <div class="editor__footer">
             <div class="editor__footer--left text-right">
-              <a :href="downloadUrl" :download="`Optimized ${cssFileName}`">
+              <a :href="downloadUrl" :download="`snapped.${cssFileName}`">
                 <button class="editor__btn util-btn right">
                   <mdi :path="mdiFileDownload" class="icon" size="20" />
                   <span class="icon_label">Download Code</span>
@@ -83,6 +83,7 @@ import Mdi from '@/components/Mdi.vue';
 import sweetAlert from 'sweetalert2';
 import Switches from '@/components/Switches.vue';
 import Preview from '@/components/Preview.vue';
+import FileImportExport from '@/util/fileImportExport';
 
 @Options({
   data() {
@@ -92,8 +93,9 @@ import Preview from '@/components/Preview.vue';
       mdiContentCopy,
       mdiFileDownload,
       mdiFileUploadOutline,
-      inputText: '// code',
+      inputText: '',
       outputText: '',
+      fileImportExport: new FileImportExport(),
       snap: new SnapCss(),
       cssFileName: 'CSS.css',
       htmlFileName: 'file.html',
@@ -108,6 +110,17 @@ import Preview from '@/components/Preview.vue';
   },
   computed: {
     downloadUrl() {
+      if (
+        this.wholeText &&
+        (this.cssFileName.endsWith('.html') ||
+          this.cssFileName.endsWith('.vue'))
+      ) {
+        return this.fileImportExport.exportToVueHTML(
+          this.wholeText,
+          this.outputText
+        );
+      }
+
       return `data:text/plain;charset=utf-8, ${encodeURIComponent(
         this.outputText
       )}`;
@@ -196,7 +209,17 @@ import Preview from '@/components/Preview.vue';
     },
     uploadCSS(event: any) {
       this.readFile(event, (e: any) => {
-        this.inputText = e.target.result;
+        const importedFile = e.target.result;
+        if (
+          this.cssFileName.endsWith('.html') ||
+          this.cssFileName.endsWith('.vue')
+        ) {
+          this.inputText =
+            this.fileImportExport.extractCSSFromHtmlOrVue(importedFile);
+        } else {
+          this.inputText = importedFile;
+        }
+        this.wholeText = importedFile;
       });
     },
     copyCode() {
@@ -282,7 +305,7 @@ export default class Home extends Vue {}
   margin: 0 25px 0 0;
   font-size: 16px;
   border: none;
-  box-shadow: 0 10px 14px rgba(0, 0, 0, .35);
+  box-shadow: 0 10px 14px rgba(0, 0, 0, 0.35);
   padding: 10px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;


### PR DESCRIPTION
Importing CSS from .html and .vue files has been included on the web and a separate helper class has been used. We can use this class to make it available in other formats (maybe @YiseBoge I need your help). I have skipped importing css from .jsx because their no standard name for style objects and most of the time in React css are imported and used with class name and other selector. Maybe I would be happy if there is a suggestion on it and would like you to check the new helper class.